### PR TITLE
feat: improved link path handling for multiple links and shards

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -56,3 +56,7 @@ button {
 .github-fork-ribbon:before {
     background-color: #333;
 }
+
+hr.tooltip-sub-divider {
+    width: 80%;
+}

--- a/src/js/ui/ui-handler.js
+++ b/src/js/ui/ui-handler.js
@@ -6,6 +6,7 @@ let _shardSeriesData = {};
 let layer_lookup = {};
 let layerControl;
 let currentActiveSeriesLayer = null;
+let activeSite = null;
 let jsonParserWorker = null;
 
 let backgroundRenderQueue = [];
@@ -34,6 +35,9 @@ export function initMapControls(map) {
         layer_lookup[seriesSafeName] = seriesLayer;
         layerControl.addOverlay(seriesLayer, seriesSafeName);
     }
+
+    map.on('zoomend', updateAllPolylineStyles);
+    map.on('moveend', updateAllPolylineStyles);
 }
 
 export async function initMapUI(shardSeriesData) {
@@ -147,6 +151,8 @@ export async function displaySeries(seriesName, source = "user") {
     if (currentActiveSeriesLayer && map.hasLayer(currentActiveSeriesLayer)) {
         map.removeLayer(currentActiveSeriesLayer);
     }
+    activeSite = null;
+
     const newSeriesLayer = layer_lookup[seriesName];
     if (newSeriesLayer) {
         newSeriesLayer.addTo(map);
@@ -166,15 +172,15 @@ export function siteButtonHandler() {
     $(this).css("font-weight", "bold");
     $(this).siblings("button").css("font-weight", "normal");
 
-    var layer = layer_lookup[this.id];
-    map.fitBounds(layer.getBounds());
+    activeSite = layer_lookup[this.id];
+    map.fitBounds(activeSite.getBounds());
     location.hash = this.id;
-    layer.eachLayer(function (l) {
+    activeSite.eachLayer(function (l) {
         if (l instanceof L.Polyline) {
-            if (l.shardPath) l.shardPath.forEach((s) => s.motionStart());
+            if (l.shardPath) l.shardPath.motionStart();
         }
     });
-    var d = layer.data;
+    updateAllPolylineStyles();
 }
 
 export async function handleCustomFile() {
@@ -212,7 +218,7 @@ export async function handleCustomFile() {
                 addSitesToSeriesLayer(seriesSafeName, siteLayers);
 
                 $("#series").append(`<option value="${seriesSafeName}">${file.name}</option>`);
-                $("#series").val(seriesSafeName).change();
+                $("#series").val(seriesSafeName).trigger("change");
                 $("button").off("click").on("click", siteButtonHandler);
 
                 updateLoadingDetails(100);
@@ -238,4 +244,40 @@ export function updateLoadingDetails(progress, message) {
     } else {
         loadingOverlay.style.display = "flex";
     }
+}
+
+// Dynamically create the dashes on links where there are bi-directional jumps
+export function applyDynamicDashArray(polyline, map) {
+    const VISIBLE_PATTERN_PIXELS = 90;
+
+    const latlngs = polyline.getLatLngs();
+    let totalDistancePixels = 0;
+
+    for (let i = 0; i < latlngs.length - 1; i++) {
+        const startPoint = map.latLngToLayerPoint(latlngs[i]);
+        const endPoint = map.latLngToLayerPoint(latlngs[i + 1]);
+        totalDistancePixels += startPoint.distanceTo(endPoint);
+    }
+
+    const G_middle_pixels = Math.max(0, totalDistancePixels - VISIBLE_PATTERN_PIXELS);
+
+    const dashArraySegments = [
+        10, 5, 5, 5, 5, 5, 5, 5,
+        G_middle_pixels,
+        5, 5, 5, 5, 5, 5, 5, 10
+    ];
+
+    polyline.setStyle({
+        dashArray: dashArraySegments.join(',')
+    });
+}
+
+function updateAllPolylineStyles() {
+    if (!activeSite) return;
+
+    activeSite.eachLayer(function (l) {
+        if (l instanceof L.Polyline && l.biDirectionalJumps) {
+            applyDynamicDashArray(l, map);
+        }
+    });
 }


### PR DESCRIPTION
As reported as a known issue in [PR7](https://github.com/neon-ninja/shards/pull/7):

> The detail of the shards which jump along the same link between portals are not catered for in the tooltip. This can occur when a shard traverses the same path in which a previous shard has used, either at a different time or if the shards swap portals along the same link. This happened at least twice in Cambridge so can be replicated fairly easily.

I've added a new section to the processed data - link paths. This increases the processed shard data by about 180KB but provides a structure to solve the main problem - multiple "links" were being rendered on top of each other for one path. This can happen in the rare occasion where multiple links have been created between two portals (triple egg water fountain at Denpasar, also different factions), but also happened when shards were jumping from either end of the link (twice on Stage 3, 2014 Tour de France Starting Line in Cambridge).

I have consolidated the rendering so only one link is created by leaflet, and the information in the tooltip has been updated to include all links and shard jumps.

This also allows me to add the following enhancements:
* Hovering over a link path will start the motion of all applicable shards.
* Updated the dashes on the link lines so that the dashes to indicate a shard has jumped from that portal is now shown at both ends when applicable.

Whilst testing this against Denpasar and Chemnitz, I also spotted that the timezone wasn't being applied within the link tooltips, which I have fixed.

Available for testing at https://yeggstry.github.io/shards/