### PR TITLE
Updated CI pipeline to align with repo move

### DIFF
--- a/.agent/rules/standards.md
+++ b/.agent/rules/standards.md
@@ -91,6 +91,8 @@ You are my senior technical partner. Since I am a solo developer, focus on **mai
     - `main` branch: Stable releases & production deployment
     - `feat/*` and `fix/*` branches: Feature development (triggers unversioned development previews)
 - **Previews:** Every push to a non-main branch generates a downloadable `dist` artifact in GitHub Actions for verification.
+- **Local Verification:**
+    - Use `npm run preview` to automatically download and test the latest CI build for your branch (requires GitHub CLI `gh`).
 - **Configuration:** See `.releaserc` for the complete semantic-release configuration
 
 ## Deployment Vibe

--- a/.agent/rules/standards.md
+++ b/.agent/rules/standards.md
@@ -15,6 +15,10 @@ You are my senior technical partner. Since I am a solo developer, focus on **mai
 - **Naming:** Use `camelCase` for variables/functions. Use `kebab-case` for source files to match existing project convention.
 - **Errors:** Always wrap async calls in try/catch blocks with clear console logging.
 
+## UI & Styling
+
+- **CSS:** Do not use inline styles. Always create a new class in a css file and assign the styling to that.
+
 ## Tools
 
 - **Build:** Use npm (as configured in package.json). Ensure the project-specific version is used.
@@ -40,55 +44,53 @@ You are my senior technical partner. Since I am a solo developer, focus on **mai
 - Keep components under 150 lines. If they get larger, suggest a refactor.
 - Never delete comments in my code unless they are objectively outdated.
 
-## Maintenance (Clean Slate Sync)
+## Maintenance (Post-Release Workspace Sync)
 
-- **Clean Slate Sync:** To sync the fork with upstream after a release, prune stale tags/branches, and clear alpha releases:
+- **Post-Release Workspace Sync:** To sync with origin and tidy the local environment after a release:
 
     ```bash
-    # 1. Fetch latest from all remotes and prune deleted references
-    git fetch upstream --tags --prune --prune-tags
-    git fetch origin --prune --prune-tags
+    # 1. Fetch latest and prune deleted references
+    git fetch origin --tags --prune --prune-tags
 
-    # 2. Reset main to upstream
+    # 2. Update main (safe fast-forward only)
     git checkout main
-    git reset --hard upstream/main
+    git pull --ff-only
 
-    # 3. Purge local tags and re-sync with upstream
+    # 3. Purge local tags and re-sync with origin
     git tag -l | xargs git tag -d
-    git fetch upstream --tags
+    git fetch origin --tags
 
     # 4. Remove alpha tags from origin
     git tag -l "*-alpha*" | xargs -I {} git push origin :refs/tags/{}
 
-    # 5. Force update origin main and tags
-    git push origin main --force
-    git push origin --tags --force
+    # 5. Prune local branches already merged into main
+    git branch --merged main | grep -v '^\*' | grep -v 'main' | xargs -r git branch -d
 
-    # 6. Final prune of stale tracking branches
+    # 6. Final prune
     git remote prune origin
-    git remote prune upstream
     ```
 
 ## Version Management & Releases
 
 - **Semantic Release:** This project uses [semantic-release](https://github.com/semantic-release/semantic-release) for automated version management and publishing.
 - **How it works:**
-  - Versions are automatically determined based on commit messages following [Conventional Commits](https://www.conventionalcommits.org/)
-  - The semantic-release workflow runs on CI after merges to `main` branch
-  - Version tracking is done via **git tags** (e.g., `v1.16.1`) - this is the source of truth for versions
-  - **IMPORTANT:** `package.json` version should remain as `0.0.0-semantically-released` (placeholder) because `npmPublish: false` is configured
-  - The version in package.json is NOT updated by semantic-release when npmPublish is disabled
+    - Versions are automatically determined based on commit messages following [Conventional Commits](https://www.conventionalcommits.org/)
+    - The semantic-release workflow runs on CI after merges to `main` branch
+    - Version tracking is done via **git tags** (e.g., `v1.16.1`) - this is the source of truth for versions
+    - **IMPORTANT:** `package.json` version should remain as `0.0.0-semantically-released` (placeholder) because `npmPublish: false` is configured
+    - The version in package.json is NOT updated by semantic-release when npmPublish is disabled
 - **Commit message format:**
-  - `feat:` triggers a **minor** version bump (e.g., 1.16.0 → 1.17.0)
-  - `fix:` triggers a **patch** version bump (e.g., 1.16.0 → 1.16.1)
-  - `BREAKING CHANGE:` in footer triggers a **major** version bump (e.g., 1.16.0 → 2.0.0)
-  - `refactor:`, `ci:`, `docs(README):` trigger **patch** bumps (custom rules in `.releaserc`)
-  - Other types like `chore:`, `docs:`, `style:`, `test:` do NOT trigger releases
-  - **To manually trigger a release:** Use `fix:` for a patch, `feat:` for minor, or commit with `BREAKING CHANGE:` footer for major
+    - `feat:` triggers a **minor** version bump (e.g., 1.16.0 → 1.17.0)
+    - `fix:` triggers a **patch** version bump (e.g., 1.16.0 → 1.16.1)
+    - `BREAKING CHANGE:` in footer triggers a **major** version bump (e.g., 1.16.0 → 2.0.0)
+    - `refactor:`, `ci:`, `docs(README):` trigger **patch** bumps (custom rules in `.releaserc`)
+    - Other types like `chore:`, `docs:`, `style:`, `test:` do NOT trigger releases
+    - **To manually trigger a release:** Use `fix:` for a patch, `feat:` for minor, or commit with `BREAKING CHANGE:` footer for major
 - **Finding current version:** Always check git tags with `git fetch --tags && git tag --list | tail -5` to see the latest released version
 - **Branch strategy:**
-  - `main` branch: stable releases
-  - `feat/*` and `fix/*` branches: alpha pre-releases
+    - `main` branch: Stable releases & production deployment
+    - `feat/*` and `fix/*` branches: Feature development (triggers unversioned development previews)
+- **Previews:** Every push to a non-main branch generates a downloadable `dist` artifact in GitHub Actions for verification.
 - **Configuration:** See `.releaserc` for the complete semantic-release configuration
 
 ## Deployment Vibe

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,9 +34,13 @@ jobs:
                   LATEST_VERSION=$(git describe --tags --always --dirty | sed 's/^v//')
                   APP_VERSION=$LATEST_VERSION npm run build
 
+            - name: Sanitize branch name
+              id: sanitize
+              run: echo "branch=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+
             - name: Upload Preview Artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: preview-${{ github.ref_name }}
+                  name: preview-${{ steps.sanitize.outputs.branch }}
                   path: "./dist"
                   if-no-files-found: error

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,42 @@
+name: Development Preview
+
+on:
+    push:
+        branches-ignore:
+            - main
+    workflow_dispatch:
+
+jobs:
+    build_preview:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+
+            - name: Install python dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements.txt
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "lts/*"
+
+            - name: Install node dependencies
+              run: npm install
+
+            - name: Build
+              run: |
+                  # Get accurate version string for the preview (e.g. 1.16.1-2-g1234abc)
+                  # If no tags exist, defaults to 0.0.0-git_hash
+                  LATEST_VERSION=$(git describe --tags --always --dirty | sed 's/^v//')
+                  APP_VERSION=$LATEST_VERSION npm run build
+
+            - name: Upload Preview Artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: preview-${{ github.ref_name }}
+                  path: "./dist"
+                  if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
-name: Release Map Application
+name: Release & Deploy
 
 on:
     push:
         branches:
             - main
-            - "feat/*"
-            - "fix/*"
     workflow_dispatch:
 
 permissions:
@@ -44,7 +42,14 @@ jobs:
             - name: Install node dependencies
               run: npm install
 
-            - name: Tag release
+            - name: Initial Build (Fallback/Manual)
+              run: |
+                  # Get latest tag (e.g. v1.16.1) or fallback to 0.0.0
+                  LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+                  # Strip the 'v' prefix for the build
+                  APP_VERSION=${LATEST_TAG#v} npm run build
+
+            - name: Tag & Release
               id: semantic
               run: npx semantic-release --repository-url "https://github.com/${{ github.repository }}.git"
 
@@ -55,11 +60,10 @@ jobs:
                   path: "./dist"
         outputs:
             new-release-published: ${{ steps.semantic.outputs.new-release-published }}
-            is-manual-trigger: ${{ github.event_name == 'workflow_dispatch' }}
 
-    deploy_pages:
+    deploy:
         needs: [release]
-        if: needs.release.outputs.new-release-published == 'true' || needs.release.outputs.is-manual-trigger == 'true'
+        if: needs.release.outputs.new-release-published == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         environment:
             name: github-pages

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cache.sqlite
 
 # Act secrets
 .secrets
+# Preview artifacts
+.preview/

--- a/.releaserc
+++ b/.releaserc
@@ -1,15 +1,6 @@
 {
     "branches": [
-        "main",
-        "next",
-        {
-            "name": "feat/*",
-            "prerelease": "alpha"
-        },
-        {
-            "name": "fix/*",
-            "prerelease": "alpha"
-        }
+        "main"
     ],
     "plugins": [
         [
@@ -98,13 +89,18 @@
         [
             "@semantic-release/exec",
             {
-                "publishCmd": "npm run build"
+                "publishCmd": "APP_VERSION=${nextRelease.version} npm run build && zip -r ingress-shards-map-${nextRelease.version}.zip dist"
             }
         ],
         [
             "@semantic-release/github",
             {
-                "assets": []
+                "assets": [
+                    {
+                        "path": "ingress-shards-map-*.zip",
+                        "label": "Ingress Shards Map (${nextRelease.version})"
+                    }
+                ]
             }
         ]
     ]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "ci-data-processor": "node scripts/pre-processor-loader.js",
         "mkdir:gen": "node -e \"if (!require('fs').existsSync('gen')) require('fs').mkdirSync('gen', { recursive: true })\"",
         "prepare:data": "npm run mkdir:gen && npm run ci-geocode && npm run ci-data-processor",
-        "validate": "npm run clean && npm run build"
+        "validate": "npm run clean && npm run build",
+        "preview": "node scripts/preview-ci-artifact.js"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "ingress-shards-map",
+    "name": "@ingress-shards/ingress-shards-map",
     "version": "0.0.0-semantically-released",
     "description": "Interactive map of shard data from Ingress events",
     "author": {

--- a/scripts/preview-ci-artifact.js
+++ b/scripts/preview-ci-artifact.js
@@ -1,0 +1,53 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const previewDir = path.join(rootDir, '.preview');
+
+try {
+    // 1. Get and sanitize current branch name
+    const branch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+    if (!branch) {
+        throw new Error('Could not determine current branch.');
+    }
+    const sanitizedBranch = branch.replace(/\//g, '-');
+    const artifactName = `preview-${sanitizedBranch}`;
+
+    console.log(`🔍 Searching for artifact: ${artifactName}...`);
+
+    // 2. Clear previous preview
+    if (fs.existsSync(previewDir)) {
+        fs.rmSync(previewDir, { recursive: true, force: true });
+    }
+
+    // 3. Download from GitHub using gh CLI
+    console.log(`📥 Downloading latest artifact for branch "${branch}"...`);
+    execSync(`gh run download --name "${artifactName}" --dir "${previewDir}"`, {
+        stdio: 'inherit',
+        cwd: rootDir
+    });
+
+    // 4. Serve the artifact
+    console.log(`\n🚀 Serving preview at http://localhost:3000`);
+    console.log(`💡 Press Ctrl+C to stop the server\n`);
+    execSync(`npx serve "${previewDir}"`, {
+        stdio: 'inherit',
+        cwd: rootDir
+    });
+
+} catch (error) {
+    if (error.message.includes('gh: command not found') || error.message.includes('gh is not recognized')) {
+        console.error('\n❌ Error: GitHub CLI ("gh") is not installed.');
+        console.log('📚 Install it via Winget: winget install --id GitHub.cli');
+        console.log('🔑 Then authenticate: gh auth login\n');
+    } else if (error.message.includes('no-artifact-found')) {
+        console.error(`\n❌ Error: No artifact named "${error.artifactName}" found.`);
+        console.log('⏳ Ensure the "Development Preview" GitHub Action has finished successfully.\n');
+    } else {
+        console.error(`\n❌ Error: ${error.message}\n`);
+    }
+    process.exit(1);
+}

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -4,7 +4,8 @@ import common, { packageJson } from './webpack.common.js';
 const REPO_NAME = '/';
 
 export default (env) => {
-    return merge(common(env, { appVersion: packageJson.version }), {
+    const appVersion = process.env.APP_VERSION || packageJson.version;
+    return merge(common(env, { appVersion }), {
         mode: 'production',
         output: {
             publicPath: REPO_NAME,


### PR DESCRIPTION
Since there have been some issues with the release process, particularly with some leftovers from when I had the repo forked and was wanting to do a github page build for preview purposes, I've simplified the release process.

For any branch other than main, a preview build is created. This can be retrieved and run locally with `npm run preview`. gh and npx are required to run this process, but is useful for validating the changes made through the ci pipeline.

The main branch process hasn't changed much, apart from a build beforehand in case a release isn't triggered from the new commits.

I would recommend using conventional commits in order to track changes and creating releases moving forward.