### PR TITLE
fix(deps): pin conventionalcommits to restore release notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@eslint/js": "^10.0.1",
                 "@eslint/json": "^2.0.1",
                 "@semantic-release/exec": "^7.1.0",
-                "conventional-changelog-conventionalcommits": "^10.3.0",
+                "conventional-changelog-conventionalcommits": "~9.3.1",
                 "css-loader": "^7.1.4",
                 "eslint": "^10.8.1",
                 "globals": "^16.5.0",
@@ -119,16 +119,6 @@
             "optional": true,
             "engines": {
                 "node": ">=0.1.90"
-            }
-        },
-        "node_modules/@conventional-changelog/template": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
-            "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=22"
             }
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -2860,16 +2850,16 @@
             }
         },
         "node_modules/conventional-changelog-conventionalcommits": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
-            "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+            "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "@conventional-changelog/template": "^1.3.0"
+                "compare-func": "^2.0.0"
             },
             "engines": {
-                "node": ">=22"
+                "node": ">=18"
             }
         },
         "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@eslint/js": "^10.0.1",
         "@eslint/json": "^2.0.1",
         "@semantic-release/exec": "^7.1.0",
-        "conventional-changelog-conventionalcommits": "^10.3.0",
+        "conventional-changelog-conventionalcommits": "~9.3.1",
         "css-loader": "^7.1.4",
         "eslint": "^10.8.1",
         "globals": "^16.5.0",


### PR DESCRIPTION
Pin conventional-changelog-conventionalcommits to ~9.3.1.